### PR TITLE
gpu support for k8s

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/tensorflow/models
 [submodule "external/kubespray"]
 	path = external/kubespray
-	url = https://github.com/kubernetes-incubator/kubespray
+	url = https://github.com/pwais/kubespray
 [submodule "external/tf_cnnvis"]
 	path = external/tf_cnnvis
 	url = https://github.com/pwais/tf_cnnvis

--- a/cluster/setup_16.04.sh
+++ b/cluster/setup_16.04.sh
@@ -26,7 +26,7 @@ add-apt-repository \
    $(lsb_release -cs) \
    stable"
 apt-get update
-apt-get install -y docker-ce=18.06.1~ce~3-0~ubuntu
+apt-get install -y docker-ce=5:18.09.0~3-0~ubuntu-xenial
 usermod -aG docker au
 
 ## nvidia-docker
@@ -38,6 +38,12 @@ curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.li
 apt-get update
 apt-get install -y nvidia-docker2
 pkill -SIGHUP dockerd
+
+# TODO only make nvidia default for cloud machines.  This might break if
+# machine does not have GPUs (I forget)
+# https://github.com/NVIDIA/k8s-device-plugin#preparing-your-gpu-nodes
+python -c 'import json; s = json.load(open("/etc/docker/daemon.json")); s["default-runtime"] = "nvidia"; json.dump(s, open("/etc/docker/daemon.json", "w"), indent=4)'
+cat /etc/docker/daemon.json
 
 # Passwordless sudo
 echo "au ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/kubespray/inventory/default/group_vars/all/all.yml
+++ b/kubespray/inventory/default/group_vars/all/all.yml
@@ -4,7 +4,18 @@
 ## anything else. In the opposite, Debian has already all its dependencies fullfiled, then bootstrap_os should be set to `none`.
 bootstrap_os: none
 
-docker_versioned_pkg: 
+# docker_versioned_pkg: 
+
+# Docker changed their version naming scheme again :P
+# We need 18.09 because nvidia-docker wants that version.
+docker_version: '18.09'
+# docker_versioned_pkg:
+#   'latest': docker-ce
+#   '18.03': docker-ce=18.03.1~ce-3-0~ubuntu
+#   '18.06': docker-ce=18.06.1~ce~3-0~ubuntu
+#   '18.09': docker-ce=5:18.09.0~3-0~ubuntu-xenial
+#   'stable': docker-ce=18.06.1~ce~3-0~ubuntu
+#   'edge': docker-ce=18.06.1~ce~3-0~ubuntu
 
 ## Directory where etcd data stored
 etcd_data_dir: /var/lib/etcd
@@ -18,7 +29,6 @@ bin_dir: /usr/local/bin
 ## environments where the nodes are accessed remotely by the "public" ip,
 ## but don't know about that address themselves.
 #access_ip: 1.1.1.1
-
 
 ## External LB example config
 ## apiserver_loadbalancer_domain_name: "elb.some.domain"

--- a/kubespray/inventory/default/group_vars/all/docker.yml
+++ b/kubespray/inventory/default/group_vars/all/docker.yml
@@ -1,6 +1,10 @@
 ## Uncomment this if you want to force overlay/overlay2 as docker storage driver
 ## Please note that overlay2 is only supported on newer kernels
-#docker_storage_options: -s overlay2
+# docker_storage_options: -s overlay2
+
+# The following packages have unmet dependencies:
+#  nvidia-docker2 : Depends: docker-ce (= 5:18.09.0~3-0~ubuntu-xenial) but 18.06.1~ce~3-0~ubuntu is to be installed or
+#                            docker-ee (= 5:18.09.0~3-0~ubuntu-xenial) but it is not installable
 
 ## Enable docker_container_storage_setup, it will configure devicemapper driver on Centos7 or RedHat7.
 docker_container_storage_setup: false

--- a/kubespray/inventory/default/group_vars/k8s-cluster/k8s-cluster.yml
+++ b/kubespray/inventory/default/group_vars/k8s-cluster/k8s-cluster.yml
@@ -179,14 +179,15 @@ persistent_volumes_enabled: false
 
 ## Container Engine Acceleration
 ## Enable container accelertion feature, for example use gpu acceleration in containers
-nvidia_accelerator_enabled: true
+#nvidia_accelerator_enabled: true
 
 ## Nvidia GPU driver install. Install will by done by a (init) pod running as a daemonset.
 ## Important: if you use Ubuntu then you should set in all.yml 'docker_storage_options: -s overlay2'
 ## Array with nvida_gpu_nodes, leave empty or comment if you dont't want to install drivers.
 ## Labels and taints won't be set to nodes if they are not in the array.
-# nvidia_gpu_nodes:
-#   - kube-gpu-001
+#nvidia_gpu_nodes:
+#  - kube-gpu-001
+#  - kube-gpu-002
 # nvidia_driver_version: "384.111"
 ## flavor can be tesla or gtx
-# nvidia_gpu_flavor: gtx
+#nvidia_gpu_flavor: gtx


### PR DESCRIPTION
We couldn't get kubespray nvidia thing to work, so we just override docker to use nvidia by default in `/etc/docker/daemon.json` as nvidia recommends. 